### PR TITLE
refactor generate_sshconfig provider functions

### DIFF
--- a/providers/do-functions.sh
+++ b/providers/do-functions.sh
@@ -78,55 +78,88 @@ instance_pretty() {
         totals="_,_,_,Instances,$droplets,Total,\$$totalPrice"
         #data is sorted by default by field name
         data=$(echo $data | jq  -r "$fields")
-        (echo "$header" && echo "$data" && echo $totals) | sed 's/"//g' | column -t -s, 
+        (echo "$header" && echo "$data" && echo $totals) | sed 's/"//g' | column -t -s,
 }
 
 ###################################################################
 #  Dynamically generates axiom's SSH config based on your cloud inventory
 #  Choose between generating the sshconfig using private IP details, public IP details or optionally lock
-#  Lock will never generate an SSH config and only used the cached config ~/.axiom/.sshconfig 
+#  Lock will never generate an SSH config and only used the cached config ~/.axiom/.sshconfig
 #  Used for axiom-exec axiom-fleet axiom-ssh
 #
 generate_sshconfig() {
-	accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
-	current=$(readlink -f "$AXIOM_PATH/axiom.json" | rev | cut -d / -f 1 | rev | cut -d . -f 1)> /dev/null 2>&1
-	sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
-	droplets="$(instances)"
-	echo -n "" > $sshnew
-	echo -e "\tServerAliveInterval 60\n" >> $sshnew
-	sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-	echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
-	generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
+    sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+    sshkey=$(jq -r '.sshkey' < "$AXIOM_PATH/axiom.json")
+    generate_sshconfig=$(jq -r '.generate_sshconfig' < "$AXIOM_PATH/axiom.json")
+    droplets="$(instances)"
 
-	if [[ "$generate_sshconfig" == "private" ]]; then
+    # handle lock/cache mode
+    if [[ "$generate_sshconfig" == "lock" ]] || [[ "$generate_sshconfig" == "cache" ]] ; then
+        echo -e "${BYellow}Using cached SSH config. No regeneration performed. To revert run:${Color_Off} ax ssh --just-generate"
+        return 0
+    fi
 
-	 echo -e "Warning your SSH config generation toggle is set to 'Private' for account : $(echo $current)."
-	 echo -e "axiom will always attempt to SSH into the instances from their private backend network interface. To revert run: axiom-ssh --just-generate"
-	  for name in $(echo "$droplets" | jq -r '.[].name')
-	  do
-	   ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"private\") | .ip_address" | head -1)
-	   if [[ -n "$ip" ]]; then
-	    echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-	   fi
-          done
-	 mv $sshnew $AXIOM_PATH/.sshconfig
+    # handle private mode
+    if [[ "$generate_sshconfig" == "private" ]] ; then
+        echo -e "${BYellow}Using instances private Ips for SSH config. To revert run:${Color_Off} ax ssh --just-generate"
+    fi
 
-	elif [[ "$generate_sshconfig" == "cache" ]]; then
-	 echo -e "Warning your SSH config generation toggle is set to 'Cache' for account : $(echo $current)."
-	 echo -e "axiom will never attempt to regenerate the SSH config. To revert run: axiom-ssh --just-generate"
+    # create empty SSH config
+    echo -n "" > "$sshnew"
+    {
+        echo -e "ServerAliveInterval 60"
+        echo -e "IdentityFile $HOME/.ssh/$sshkey"
+    } >> "$sshnew"
 
-	 # If anything but "private" or "cache" is parsed from the generate_sshconfig in account.json, generate public IPs only
-	 #
-	  else
-	   for name in $(echo "$droplets" | jq -r '.[].name')
-	   do
-	    ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .networks.v4[] | select(.type==\"public\") | .ip_address" | head -1)
-	    if [[ -n "$ip" ]]; then
-	     echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-	    fi
-	  done
-	 mv $sshnew $AXIOM_PATH/.sshconfig
-	fi
+    declare -A name_counts
+
+    echo "$droplets" | jq -c '.[]?' 2>/dev/null | while read -r droplet; do
+        # extract fields
+        name=$(echo "$droplet" | jq -r '.name? // empty' 2>/dev/null)
+        public_ip=$(echo "$droplet" | jq -r '.networks.v4[]? | select(.type=="public") | .ip_address? // empty' 2>/dev/null | head -n 1)
+        private_ip=$(echo "$droplet" | jq -r '.networks.v4[]? | select(.type=="private") | .ip_address? // empty' 2>/dev/null | head -n 1)
+
+        # skip if name is empty
+        if [[ -z "$name" ]] ; then
+            continue
+        fi
+
+        # select IP based on configuration mode
+        if [[ "$generate_sshconfig" == "private" ]]; then
+            ip="$private_ip"
+        else
+            ip="$public_ip"
+        fi
+
+        # skip if no IP is available
+        if [[ -z "$ip" ]]; then
+            continue
+        fi
+
+        # track hostnames in case of duplicates
+        if [[ -n "${name_counts[$name]}" ]]; then
+            count=${name_counts[$name]}
+            hostname="${name}-${count}"
+            name_counts[$name]=$((count + 1))
+        else
+            hostname="$name"
+            name_counts[$name]=2  # Start duplicate count at 2
+        fi
+
+        # add SSH config entry
+        echo -e "Host $hostname\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> "$sshnew"
+    done
+
+    # validate and apply the new SSH config
+    if ssh -F "$sshnew" null -G > /dev/null 2>&1; then
+        mv "$sshnew" "$AXIOM_PATH/.sshconfig"
+    else
+        echo -e "${BRed}Error: Generated SSH config is invalid. Details:${Color_Off}"
+        ssh -F "$sshnew" null -G
+        cat "$sshnew"
+        rm -f "$sshnew"
+        return 1
+    fi
 }
 
 ###################################################################

--- a/providers/gcp-functions.sh
+++ b/providers/gcp-functions.sh
@@ -97,35 +97,77 @@ instance_pretty() {
 #  Used for axiom-exec axiom-fleet axiom-ssh
 #
 generate_sshconfig() {
-    accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
-    current=$(readlink -f "$AXIOM_PATH/axiom.json" | rev | cut -d / -f 1 | rev | cut -d . -f 1) >/dev/null 2>&1
     sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
-    instances_data=$(instances)
-    echo -n "" > $sshnew
-    echo -e "\tServerAliveInterval 60\n" >> $sshnew
-    sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-    echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
-    generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
+    sshkey=$(jq -r '.sshkey' < "$AXIOM_PATH/axiom.json")
+    generate_sshconfig=$(jq -r '.generate_sshconfig' < "$AXIOM_PATH/axiom.json")
+    droplets="$(instances)"
 
-    if [[ "$generate_sshconfig" == "private" ]]; then
-        echo -e "Warning: Generating SSH config for private IP addresses"
-        for name in $(echo "$instances_data" | jq -r '.[].name'); do
-            ip=$(echo "$instances_data" | jq -r ".[] | select(.name==\"$name\") | .networkInterfaces[0].networkIP")
-            if [[ -n "$ip" ]]; then
-                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-            fi
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
-    elif [[ "$generate_sshconfig" == "cache" ]]; then
-        echo -e "Warning: SSH config is cached, no new generation"
+    # handle lock/cache mode
+    if [[ "$generate_sshconfig" == "lock" ]] || [[ "$generate_sshconfig" == "cache" ]] ; then
+        echo -e "${BYellow}Using cached SSH config. No regeneration performed. To revert run:${Color_Off} ax ssh --just-generate"
+        return 0
+    fi
+
+    # handle private mode
+    if [[ "$generate_sshconfig" == "private" ]] ; then
+        echo -e "${BYellow}Using instances private Ips for SSH config. To revert run:${Color_Off} ax ssh --just-generate"
+    fi
+
+    # create empty SSH config
+    echo -n "" > "$sshnew"
+    {
+        echo -e "ServerAliveInterval 60"
+        echo -e "IdentityFile $HOME/.ssh/$sshkey"
+    } >> "$sshnew"
+
+    declare -A name_counts
+
+    echo "$droplets" | jq -c '.[]?' 2>/dev/null | while read -r droplet; do
+        # extract fields
+        name=$(echo "$droplet" | jq -r '.name? // empty' 2>/dev/null)
+        public_ip=$(echo "$droplet" | jq -r '.networkInterfaces[0]?.accessConfigs[0]?.natIP? // empty' 2>/dev/null | head -n 1)
+        private_ip=$(echo "$droplet" | jq -r '.networkInterfaces[0]?.networkIP? // empty' 2>/dev/null | head -n 1)
+
+        # skip if name is empty
+        if [[ -z "$name" ]] ; then
+            continue
+        fi
+
+        # select IP based on configuration mode
+        if [[ "$generate_sshconfig" == "private" ]]; then
+            ip="$private_ip"
+        else
+            ip="$public_ip"
+        fi
+
+        # skip if no IP is available
+        if [[ -z "$ip" ]]; then
+            continue
+        fi
+
+        # track hostnames in case of duplicates
+        if [[ -n "${name_counts[$name]}" ]]; then
+            count=${name_counts[$name]}
+            hostname="${name}-${count}"
+            name_counts[$name]=$((count + 1))
+        else
+            hostname="$name"
+            name_counts[$name]=2  # Start duplicate count at 2
+        fi
+
+        # add SSH config entry
+        echo -e "Host $hostname\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> "$sshnew"
+    done
+
+    # validate and apply the new SSH config
+    if ssh -F "$sshnew" null -G > /dev/null 2>&1; then
+        mv "$sshnew" "$AXIOM_PATH/.sshconfig"
     else
-        for name in $(echo "$instances_data" | jq -r '.[].name'); do
-            ip=$(echo "$instances_data" | jq -r ".[] | select(.name==\"$name\") | .networkInterfaces[0].accessConfigs[0].natIP")
-            if [[ -n "$ip" ]]; then
-                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-            fi
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
+        echo -e "${BRed}Error: Generated SSH config is invalid. Details:${Color_Off}"
+        ssh -F "$sshnew" null -G
+        cat "$sshnew"
+        rm -f "$sshnew"
+        return 1
     fi
 }
 
@@ -174,7 +216,6 @@ get_image_id() {
     # Return the image ID
     echo $id
 }
-
 
 ###################################################################
 # Manage snapshots (updated to manage images, keeping function names the same)

--- a/providers/hetzner-functions.sh
+++ b/providers/hetzner-functions.sh
@@ -107,45 +107,78 @@ instance_pretty() {
 # Generate SSH config specfied in generate_sshconfig key:value in account.json
 #
 generate_sshconfig() {
-accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
-current=$(ls -lh "$AXIOM_PATH/axiom.json" | awk '{ print $11 }' | tr '/' '\n' | grep json | sed 's/\.json//g') > /dev/null 2>&1
-droplets="$(instances)"
-sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
-echo -n "" > $sshnew
-echo -e "\tServerAliveInterval 60\n" >> $sshnew
-sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
-generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
+    sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+    sshkey=$(jq -r '.sshkey' < "$AXIOM_PATH/axiom.json")
+    generate_sshconfig=$(jq -r '.generate_sshconfig' < "$AXIOM_PATH/axiom.json")
+    droplets="$(instances)"
 
-if [[ "$generate_sshconfig" == "private" ]]; then
+    # handle lock/cache mode
+    if [[ "$generate_sshconfig" == "lock" ]] || [[ "$generate_sshconfig" == "cache" ]] ; then
+        echo -e "${BYellow}Using cached SSH config. No regeneration performed. To revert run:${Color_Off} ax ssh --just-generate"
+        return 0
+    fi
 
- echo -e "Warning your SSH config generation toggle is set to 'Private' for account : $(echo $current)."
- echo -e "axiom will always attempt to SSH into the instances from their private backend network interface. To revert run: axiom-ssh --just-generate"
- for name in $(echo "$droplets" | jq -r '.[].name')
- do
- ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .private_net.ipv4.ip")
- if [[ -n "$ip" ]]; then
-  echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
- fi
- done
- mv $sshnew $AXIOM_PATH/.sshconfig
+    # handle private mode
+    if [[ "$generate_sshconfig" == "private" ]] ; then
+        echo -e "${BYellow}Using instances private Ips for SSH config. To revert run:${Color_Off} ax ssh --just-generate"
+    fi
 
- elif [[ "$generate_sshconfig" == "cache" ]]; then
- echo -e "Warning your SSH config generation toggle is set to 'Cache' for account : $(echo $current)."
- echo -e "axiom will never attempt to regenerate the SSH config. To revert run: axiom-ssh --just-generate"
+    # create empty SSH config
+    echo -n "" > "$sshnew"
+    {
+        echo -e "ServerAliveInterval 60"
+        echo -e "IdentityFile $HOME/.ssh/$sshkey"
+    } >> "$sshnew"
 
- # If anything but "private" or "cache" is parsed from the generate_sshconfig in account.json, generate public IPs only
- #
- else
- for name in $(echo "$droplets" | jq -r '.[].name')
- do
- ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .public_net.ipv4.ip")
- if [[ -n "$ip" ]]; then
-  echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
- fi
- done
- mv $sshnew $AXIOM_PATH/.sshconfig
-fi
+    declare -A name_counts
+
+    echo "$droplets" | jq -c '.[]?' 2>/dev/null | while read -r droplet; do
+        # extract fields
+        name=$(echo "$droplet" | jq -r '.name? // empty' 2>/dev/null)
+        public_ip=$(echo "$droplet" | jq -r '.public_net?.ipv4?.ip? // empty' 2>/dev/null | head -n 1)
+        private_ip=$(echo "$droplet" | jq -r '.private_net?.ipv4?.ip?  // empty' 2>/dev/null | head -n 1)
+
+        # skip if name is empty
+        if [[ -z "$name" ]] ; then
+            continue
+        fi
+
+        # select IP based on configuration mode
+        if [[ "$generate_sshconfig" == "private" ]]; then
+            ip="$private_ip"
+        else
+            ip="$public_ip"
+        fi
+
+        # skip if no IP is available
+        if [[ -z "$ip" ]]; then
+            continue
+        fi
+
+        # track hostnames in case of duplicates
+        if [[ -n "${name_counts[$name]}" ]]; then
+            count=${name_counts[$name]}
+            hostname="${name}-${count}"
+            name_counts[$name]=$((count + 1))
+        else
+            hostname="$name"
+            name_counts[$name]=2  # Start duplicate count at 2
+        fi
+
+        # add SSH config entry
+        echo -e "Host $hostname\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> "$sshnew"
+    done
+
+    # validate and apply the new SSH config
+    if ssh -F "$sshnew" null -G > /dev/null 2>&1; then
+        mv "$sshnew" "$AXIOM_PATH/.sshconfig"
+    else
+        echo -e "${BRed}Error: Generated SSH config is invalid. Details:${Color_Off}"
+        ssh -F "$sshnew" null -G
+        cat "$sshnew"
+        rm -f "$sshnew"
+        return 1
+    fi
 }
 
 ###################################################################
@@ -196,7 +229,6 @@ get_image_id() {
         fi
         echo $id
 }
-
 
 ###################################################################
 # Manage snapshots

--- a/providers/ibm-vpc-functions.sh
+++ b/providers/ibm-vpc-functions.sh
@@ -119,41 +119,83 @@ instance_pretty() {
 #  Used for axiom-exec axiom-fleet axiom-ssh
 #
 generate_sshconfig() {
-    accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
-    current=$(readlink -f "$AXIOM_PATH/axiom.json" | rev | cut -d / -f 1 | rev | cut -d . -f 1) > /dev/null 2>&1
-    instances="$(instances)"
     sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
-    echo -n "" > $sshnew
-    echo -e "\tServerAliveInterval 60\n" >> $sshnew
-    sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-    echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
-    generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
+    sshkey=$(jq -r '.sshkey' < "$AXIOM_PATH/axiom.json")
+    generate_sshconfig=$(jq -r '.generate_sshconfig' < "$AXIOM_PATH/axiom.json")
+    droplets="$(instances)"
 
-    if [[ "$generate_sshconfig" == "private" ]]; then
-        echo -e "Warning your SSH config generation toggle is set to 'Private' for account: $(echo $current)."
-        echo -e "Axiom will always attempt to SSH into the instances from their private backend network interface. To revert, run: axiom-ssh --just-generate"
-        for name in $(echo "$instances" | jq -r '.[].name'); do
-            primary_ip=$(echo "$instances" | jq -r ".[] | select(.name==\"$name\") | .primary_network_attachment.virtual_network_interface.floating_ips[0]?.address // empty")
-            network_ip=$(echo "$instances" | jq -r ".[] | select(.name==\"$name\") | .network_interfaces[].floating_ips[]?.address // empty")
-            ip=$(echo -e "$primary_ip\n$network_ip" | grep -v "^$" | head -n 1)
-            ip=${ip:-"null"}  # Assign "null" if both IPs are empty
-            echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
+    # handle lock/cache mode
+    if [[ "$generate_sshconfig" == "lock" ]] || [[ "$generate_sshconfig" == "cache" ]] ; then
+        echo -e "${BYellow}Using cached SSH config. No regeneration performed. To revert run:${Color_Off} ax ssh --just-generate"
+        return 0
+    fi
 
-    elif [[ "$generate_sshconfig" == "cache" ]]; then
-        echo -e "Warning your SSH config generation toggle is set to 'Cache' for account: $(echo $current)."
-        echo -e "Axiom will never attempt to regenerate the SSH config. To revert, run: axiom-ssh --just-generate"
+    # handle private mode
+    if [[ "$generate_sshconfig" == "private" ]] ; then
+        echo -e "${BYellow}Using instances private Ips for SSH config. To revert run:${Color_Off} ax ssh --just-generate"
+    fi
 
+    # create empty SSH config
+    echo -n "" > "$sshnew"
+    {
+        echo -e "ServerAliveInterval 60"
+        echo -e "IdentityFile $HOME/.ssh/$sshkey"
+    } >> "$sshnew"
+
+    declare -A name_counts
+
+    echo "$droplets" | jq -c '.[]?' 2>/dev/null | while read -r droplet; do
+        # extract fields
+        name=$(echo "$droplet" | jq -r '.name? // empty' 2>/dev/null)
+
+        public_primary_ip=$(echo "$droplet" | jq -r '.primary_network_attachment?.virtual_network_interface?.floating_ips[0]?.address? // empty' 2>/dev/null | head -n 1)
+        public_network_ip=$(echo "$droplet" | jq -r '.network_interfaces[]?.floating_ips[]?.address? // empty' 2>/dev/null | head -n 1)
+        public_ip=$(echo -e "$public_primary_ip\n$public_network_ip" | grep -v "^$" | head -n 1)
+
+        private_primary_ip=$(echo "$droplet" | jq -r '.primary_network_attachment?.primary_ip?.address? // empty' 2>/dev/null | head -n 1)
+        private_network_ip=$(echo "$droplet" | jq -r '.network_interfaces[]?.primary_ip?.address? // empty' 2>/dev/null | head -n 1)
+        private_ip=$(echo -e "$private_primary_ip\n$private_network_ip" | grep -v "^$" | head -n 1)
+
+        # skip if name is empty
+        if [[ -z "$name" ]] ; then
+            continue
+        fi
+
+        # select IP based on configuration mode
+        if [[ "$generate_sshconfig" == "private" ]]; then
+            ip="$private_ip"
+        else
+            ip="$public_ip"
+        fi
+
+        # skip if no IP is available
+        if [[ -z "$ip" ]]; then
+            continue
+        fi
+
+        # track hostnames in case of duplicates
+        if [[ -n "${name_counts[$name]}" ]]; then
+            count=${name_counts[$name]}
+            hostname="${name}-${count}"
+            name_counts[$name]=$((count + 1))
+        else
+            hostname="$name"
+            name_counts[$name]=2  # Start duplicate count at 2
+        fi
+
+        # add SSH config entry
+        echo -e "Host $hostname\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> "$sshnew"
+    done
+
+    # validate and apply the new SSH config
+    if ssh -F "$sshnew" null -G > /dev/null 2>&1; then
+        mv "$sshnew" "$AXIOM_PATH/.sshconfig"
     else
-        for name in $(echo "$instances" | jq -r '.[].name'); do
-            primary_ip=$(echo "$instances" | jq -r ".[] | select(.name==\"$name\") | .primary_network_attachment.virtual_network_interface.floating_ips[0]?.address // empty")
-            network_ip=$(echo "$instances" | jq -r ".[] | select(.name==\"$name\") | .network_interfaces[].floating_ips[]?.address // empty")
-            ip=$(echo -e "$primary_ip\n$network_ip" | grep -v "^$" | head -n 1)
-            ip=${ip:-"null"}  # Assign "null" if both IPs are empty
-            echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
+        echo -e "${BRed}Error: Generated SSH config is invalid. Details:${Color_Off}"
+        ssh -F "$sshnew" null -G
+        cat "$sshnew"
+        rm -f "$sshnew"
+        return 1
     fi
 }
 

--- a/providers/scaleway-functions.sh
+++ b/providers/scaleway-functions.sh
@@ -85,42 +85,87 @@ instance_pretty() {
     totals="_,_,_,Instances,$droplets,Total"
 
     data=$(echo "$data" | jq -r "$fields")
-    (echo "$header" && echo "$data" && echo "$totals") | sed 's/"//g' | column -t -s, 
+    (echo "$header" && echo "$data" && echo "$totals") | sed 's/"//g' | column -t -s,
 }
 
 ###################################################################
 #  Dynamically generates axiom's SSH config based on your cloud inventory
-#  Choose between generating the sshconfig using private IP details, public IP details, or optionally lock
-#  Used for axiom-exec, axiom-fleet, and axiom-ssh
+#  Choose between generating the sshconfig using private IP details, public IP details or optionally lock
+#  Lock will never generate an SSH config and only used the cached config ~/.axiom/.sshconfig
+#  Used for axiom-exec axiom-fleet axiom-ssh
+#
 generate_sshconfig() {
-    accounts=$(ls -l "$AXIOM_PATH/accounts/" | grep "json" | grep -v 'total ' | awk '{ print $9 }' | sed 's/\.json//g')
-    current=$(readlink -f "$AXIOM_PATH/axiom.json" | rev | cut -d / -f 1 | rev | cut -d . -f 1) > /dev/null 2>&1
     sshnew="$AXIOM_PATH/.sshconfig.new$RANDOM"
+    sshkey=$(jq -r '.sshkey' < "$AXIOM_PATH/axiom.json")
+    generate_sshconfig=$(jq -r '.generate_sshconfig' < "$AXIOM_PATH/axiom.json")
     droplets="$(instances)"
-    echo -n "" > $sshnew
-    echo -e "\tServerAliveInterval 60\n" >> $sshnew
-    sshkey="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.sshkey')"
-    echo -e "IdentityFile $HOME/.ssh/$sshkey" >> $sshnew
-    generate_sshconfig="$(cat "$AXIOM_PATH/axiom.json" | jq -r '.generate_sshconfig')"
 
-    if [[ "$generate_sshconfig" == "private" ]]; then
-        echo -e "Warning your SSH config generation toggle is set to 'Private' for account: $(echo $current)."
-        echo -e "axiom will always attempt to SSH into the instances from their private backend network interface."
-        for name in $(echo "$droplets" | jq -r '.[].name'); do
-            ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .private_ip.address" | head -1)
-            if [[ -n "$ip" ]]; then
-                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-            fi
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
+    # handle lock/cache mode
+    if [[ "$generate_sshconfig" == "lock" ]] || [[ "$generate_sshconfig" == "cache" ]] ; then
+        echo -e "${BYellow}Using cached SSH config. No regeneration performed. To revert run:${Color_Off} ax ssh --just-generate"
+        return 0
+    fi
+
+    # handle private mode
+    if [[ "$generate_sshconfig" == "private" ]] ; then
+        echo -e "${BYellow}Using instances private Ips for SSH config. To revert run:${Color_Off} ax ssh --just-generate"
+    fi
+
+    # create empty SSH config
+    echo -n "" > "$sshnew"
+    {
+        echo -e "ServerAliveInterval 60"
+        echo -e "IdentityFile $HOME/.ssh/$sshkey"
+    } >> "$sshnew"
+
+    declare -A name_counts
+
+    echo "$droplets" | jq -c '.[]?' 2>/dev/null | while read -r droplet; do
+        # extract fields
+        name=$(echo "$droplet" | jq -r '.name // empty' 2>/dev/null)
+        public_ip=$(echo "$droplet" | jq -r '.public_ip?.address? // empty' 2>/dev/null | head -n 1)
+        private_ip=$(echo "$droplet" | jq -r '.private_ip?.address? // empty' 2>/dev/null | head -n 1)
+
+        # skip if name is empty
+        if [[ -z "$name" ]] ; then
+            continue
+        fi
+
+        # select IP based on configuration mode
+        if [[ "$generate_sshconfig" == "private" ]]; then
+            ip="$private_ip"
+        else
+            ip="$public_ip"
+        fi
+
+        # skip if no IP is available
+        if [[ -z "$ip" ]]; then
+            continue
+        fi
+
+        # track hostnames in case of duplicates
+        if [[ -n "${name_counts[$name]}" ]]; then
+            count=${name_counts[$name]}
+            hostname="${name}-${count}"
+            name_counts[$name]=$((count + 1))
+        else
+            hostname="$name"
+            name_counts[$name]=2  # Start duplicate count at 2
+        fi
+
+        # add SSH config entry
+        echo -e "Host $hostname\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> "$sshnew"
+    done
+
+    # validate and apply the new SSH config
+    if ssh -F "$sshnew" null -G > /dev/null 2>&1; then
+        mv "$sshnew" "$AXIOM_PATH/.sshconfig"
     else
-        for name in $(echo "$droplets" | jq -r '.[].name'); do
-            ip=$(echo "$droplets" | jq -r ".[] | select(.name==\"$name\") | .public_ip.address" | head -1)
-            if [[ -n "$ip" ]]; then
-                echo -e "Host $name\n\tHostName $ip\n\tUser op\n\tPort 2266\n" >> $sshnew
-            fi
-        done
-        mv $sshnew $AXIOM_PATH/.sshconfig
+        echo -e "${BRed}Error: Generated SSH config is invalid. Details:${Color_Off}"
+        ssh -F "$sshnew" null -G
+        cat "$sshnew"
+        rm -f "$sshnew"
+        return 1
     fi
 }
 


### PR DESCRIPTION
- Standardize ssh config generation logic across all cloud providers
- Avoid creating malformed sshconfig when possible 
- Validate config is valid before replacing existing sshconfig
- Append suffixes (e.g., -2, -3) to instances with duplicate names for uniqueness 
