### PR TITLE
Scaleway: Increase disk size for packer

### DIFF
--- a/images/pkr.hcl/builders/scaleway.pkr.hcl
+++ b/images/pkr.hcl/builders/scaleway.pkr.hcl
@@ -25,6 +25,9 @@ source "scaleway" "packer" {
   image_name = var.snapshot_name
   snapshot_name = var.snapshot_name
   remove_volume = "true"
+  root_volume {
+    size_in_gb = 25
+  }
 }
 
 build {


### PR DESCRIPTION
By default, Scaleway provides only a local disk of 10 Gb which is not enough when we use `ax build` – we get `no space left on device` messages after a while which result in a wrong/incomplete snapshot.