### PR TITLE
Display only multi-region custom images (uploaded or captured from instance disks)

### DIFF
--- a/providers/linode-functions.sh
+++ b/providers/linode-functions.sh
@@ -247,7 +247,7 @@ get_image_id() {
 # used for axiom-images
 #
 get_snapshots() {
-    linode-cli images list --is_public false
+    linode-cli images list --is_public false | grep --color=never -E "capabilities|distributed-sites"
 }
 
 # Delete a snapshot by its name


### PR DESCRIPTION
Only display custom images that are multi-region deployable (manually uploaded or captured from an existing compute instance disk).