### PR TITLE
Add AWS Instance Credential Metadata Authentication

### DIFF
--- a/images/pkr.hcl/builders/aws.pkr.hcl
+++ b/images/pkr.hcl/builders/aws.pkr.hcl
@@ -10,6 +10,10 @@ variable "op_random_password" {
   type = string
 }
 
+variable "security_group_id" {
+  type = string
+}
+
 variable "snapshot_name" {
   type = string
 }
@@ -19,28 +23,42 @@ variable "default_disk_size" {
   default = 20
 }
 
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}
+
+variable "aws_access_key" {
+  type = string
+  default = null
+}
+
+variable "aws_secret_access_key" {
+  type = string
+  default = null
+}
+
+variable "aws_vpc_id" {
+  type = string
+}
+
+variable "aws_subnet_id" {
+  type = string
+}
+
+
 source "amazon-ebs" "packer" {
-  #access_key = var.aws_access_key
-  #secret_key = var.aws_secret_access_key
+  access_key = var.aws_access_key != null ? var.aws_access_key : null
+  secret_key = var.aws_secret_access_key != null ? var.aws_secret_access_key : null
+  profile    = var.aws_profile != null ? var.aws_profile : null
   region     = var.region
+  vpc_id     = var.aws_vpc_id
+  subnet_id  = var.aws_subnet_id
+  security_group_id = var.security_group_id
   ami_name   = var.snapshot_name
   instance_type = var.default_size
-  security_group_id = var.security_group_id
-  associate_public_ip_address = true
+  associate_public_ip_address = var.associate_public_ip_address
   ssh_interface = "private_ip"
-
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "required"
-    http_put_response_hop_limit = 1
-  }
-  imds_support  = "v2.0" # enforces imdsv2 support on the resulting AMI
-
-  subnet_filter {
-    filters = {
-      "tag:Name": "Assessment Operations"
-    }
-  }
 
   launch_block_device_mappings {
     device_name           = "/dev/sda1"

--- a/images/pkr.hcl/builders/aws.pkr.hcl
+++ b/images/pkr.hcl/builders/aws.pkr.hcl
@@ -20,11 +20,27 @@ variable "default_disk_size" {
 }
 
 source "amazon-ebs" "packer" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_access_key
+  #access_key = var.aws_access_key
+  #secret_key = var.aws_secret_access_key
   region     = var.region
   ami_name   = var.snapshot_name
   instance_type = var.default_size
+  security_group_id = var.security_group_id
+  associate_public_ip_address = true
+  ssh_interface = "private_ip"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+  }
+  imds_support  = "v2.0" # enforces imdsv2 support on the resulting AMI
+
+  subnet_filter {
+    filters = {
+      "tag:Name": "Assessment Operations"
+    }
+  }
 
   launch_block_device_mappings {
     device_name           = "/dev/sda1"

--- a/interact/account-helpers/aws.sh
+++ b/interact/account-helpers/aws.sh
@@ -142,8 +142,7 @@ echo -e -n "${Green}Please enter a security group name above or press enter to c
 read SECURITY_GROUP
 
 # Get all available AWS regions
-all_regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output text)
-
+all_regions=$(aws ec2 describe-regions --region-names us-east-1 --query "Regions[].RegionName" --output text)
 echo -e "${BGreen}Creating or reusing the security group '$SECURITY_GROUP' in ALL AWS regions...${Color_Off}"
 
 # We will track the "last" group_id and group_owner_id found or created

--- a/interact/axiom-account
+++ b/interact/axiom-account
@@ -399,15 +399,15 @@ if [[ "$provider" == "aws" ]]; then
     aws_secret_access_key="$(jq -r '.aws_secret_access_key' "$AXIOM_PATH"/axiom.json)"
     aws_region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
 
-    if [[ -n "$aws_access_key" && -n "$aws_secret_access_key" ]]; then
-        echo -e "${BGreen}Configuring AWS CLI with credentials from axiom.json...${Color_Off}"
-        aws configure set aws_access_key_id "$aws_access_key"
-        aws configure set aws_secret_access_key "$aws_secret_access_key"
-        aws configure set region "$aws_region"
-    else
-        echo -e "${BRed}No AWS credentials found in axiom.json. Please set them manually.${Color_Off}"
-        bootstrap
-    fi
+    #if [[ -n "$aws_access_key" && -n "$aws_secret_access_key" ]]; then
+    #    echo -e "${BGreen}Configuring AWS CLI with credentials from axiom.json...${Color_Off}"
+    #    aws configure set aws_access_key_id "$aws_access_key"
+    #    aws configure set aws_secret_access_key "$aws_secret_access_key"
+    #    aws configure set region "$aws_region"
+    #else
+    #    echo -e "${BRed}No AWS credentials found in axiom.json. Please set them manually.${Color_Off}"
+    #    bootstrap
+    #fi
 
     # Check if AWS CLI is authenticated
     if ! aws sts get-caller-identity &> /dev/null; then

--- a/interact/axiom-account
+++ b/interact/axiom-account
@@ -398,16 +398,20 @@ if [[ "$provider" == "aws" ]]; then
     aws_access_key="$(jq -r '.aws_access_key' "$AXIOM_PATH"/axiom.json)"
     aws_secret_access_key="$(jq -r '.aws_secret_access_key' "$AXIOM_PATH"/axiom.json)"
     aws_region="$(jq -r '.region' "$AXIOM_PATH"/axiom.json)"
+    aws_profile="$(jq -r '.aws_profile' "$AXIOM_PATH"/axiom.json)"
 
-    #if [[ -n "$aws_access_key" && -n "$aws_secret_access_key" ]]; then
-    #    echo -e "${BGreen}Configuring AWS CLI with credentials from axiom.json...${Color_Off}"
-    #    aws configure set aws_access_key_id "$aws_access_key"
-    #    aws configure set aws_secret_access_key "$aws_secret_access_key"
-    #    aws configure set region "$aws_region"
-    #else
-    #    echo -e "${BRed}No AWS credentials found in axiom.json. Please set them manually.${Color_Off}"
-    #    bootstrap
-    #fi
+    if [[ "$aws_access_key" != "null" && "$aws_secret_access_key" != "null" ]]; then
+       echo -e "${BGreen}Configuring AWS CLI with credentials from axiom.json...${Color_Off}"
+       aws configure set aws_access_key_id "$aws_access_key"
+       aws configure set aws_secret_access_key "$aws_secret_access_key"
+       aws configure set region "$aws_region"
+    elif [[ "$aws_profile" != "null" ]]; then
+       echo -e "${BGreen}Configuring AWS CLI to use profile from axiom.json...${Color_Off}"
+       export AWS_PROFILE="$aws_profile"
+    else
+       echo -e "${BRed}No AWS credentials found in axiom.json. Please set them manually.${Color_Off}"
+       bootstrap
+    fi
 
     # Check if AWS CLI is authenticated
     if ! aws sts get-caller-identity &> /dev/null; then

--- a/modules/nuclei.json
+++ b/modules/nuclei.json
@@ -5,7 +5,7 @@
     "folder": "/home/op/nuclei-templates"
   },
   {
-    "command": "/home/op/go/bin/nuclei -update -silent ; cat input | /home/op/go/bin/nuclei -t _folder_ -jsonl -o output",
+    "command": "/home/op/go/bin/nuclei -update -silent ; cat input | /home/op/go/bin/nuclei -jsonl -o output",
     "ext": "jsonl",
     "folder": "/home/op/nuclei-templates"
   }

--- a/providers/aws-functions.sh
+++ b/providers/aws-functions.sh
@@ -113,7 +113,7 @@ instances() {
 
     # Fetch describe-instances for each region in parallel
     for region in $regions; do
-        aws ec2 describe-instances --region "$region" --output json > "$tempdir/$region.json" 2>/dev/null &
+        aws ec2 describe-instances --region "$region" --output json > "$tempdir/$region.json" &
     done
     wait
 
@@ -351,7 +351,7 @@ get_image_id() {
         for r in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
             (
                 aws ec2 describe-images --owners self --region "$r" \
-                    --query "Images[*].[Name,ImageId]" --output json 2>/dev/null \
+                    --query "Images[*].[Name,ImageId]" --output json \
                 | jq -r --arg query "$query" --arg region "$r" '.[] | select(.[0] | startswith($query)) | "\(. [1]) \($region)"' > "$tempdir/$r.txt"
             ) &
         done
@@ -378,7 +378,7 @@ get_snapshots() {
     for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
         (
             aws ec2 describe-images --owners self --region "$region" \
-                --query "Images[*].[Name,BlockDeviceMappings[0].Ebs.VolumeSize]" --output text 2>/dev/null \
+                --query "Images[*].[Name,BlockDeviceMappings[0].Ebs.VolumeSize]" --output text \
             | awk -v r="$region" '{OFS="\t"; print $1, $2, r}' >> "$tmp/all.txt"
         ) &
     done


### PR DESCRIPTION
Our current AWS deployment environment had some restrictions that required some changes to AX to allow it to function correctly. We felt those tweaks could be useful to other and wanted to share them.

The PR adds the following:

- Support for AWS EC2 Instance Metadata Credentials with the aws cli via a profile instead of requiring Access/Secret keys. 
  - We added prompts to the aws account helper, but the language could definitely use some improvement.
  - If `aws_profile` is defined in `axiom.json` then it will automatically be exported before for use by every aws function
- Support for non-default AWS VPCs and AWS Subnets which require an explicit `vpc_id` and `subnet_id`
  - Additionally re-ordered the use of `security_group_id` over `security_group_name` because the name cannot always be used on it's own.
- Support for instance deployment with a public IP address
