### PR TITLE
feat: add Arch Linux easy install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If you have any problems with this installer, or if using an unsupported OS plea
 | Debian     |    Yes    | Yes           | Debian 12     |
 | Windows    |    Yes    | Yes           | WSL w/ Ubuntu |
 | MacOS      |    Yes    | Yes           | macOS 14      |
-| Arch Linux |    Yes    | No            | Yes           |
+| Arch Linux |    Yes    | Yes           | Yes           |
 
 <br>
 

--- a/interact/account-helpers/aws.sh
+++ b/interact/account-helpers/aws.sh
@@ -44,18 +44,10 @@ if [[ "$(printf '%s\n' "$installed_version" "$AWSCliVersion" | sort -V | head -n
         rm AWSCLIV2.pkg
 
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
-            fi
-        fi
+        OS=$(detect_os)
 
         # Install AWS CLI based on specific Linux distribution
-        if [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
+        if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]] || [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
             echo -e "${BGreen}Installing/Updating AWS CLI on $OS...${Color_Off}"
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
             cd /tmp

--- a/interact/account-helpers/azure.sh
+++ b/interact/account-helpers/azure.sh
@@ -63,47 +63,43 @@ if [[ "$(printf '%s\n' "$installed_version" "$AzureCliVersion" | sort -V | head 
     # Handle Linux installation/update
     elif [[ $BASEOS == "Linux" ]]; then
         echo -e "${BGreen}Installing Azure CLI (az)...${Color_Off}"
-        sudo apt-get update -qq
-        sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y -qq
+        OS=$(detect_os)
 
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
+        if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
+            echo -e "${BGreen}Installing Azure CLI via pip on Arch...${Color_Off}"
+            pip install azure-cli
+        elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
+            sudo apt-get update -qq
+            sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y -qq
+
+            AZ_REPO=$(lsb_release -cs)
+            if [[ $AZ_REPO == "kali-rolling" ]]; then
+                check_version=$(cat /proc/version | awk '{ print $6 $7 }' | tr -d '()' | cut -d . -f 1)
+                case $check_version in
+                    Debian10)
+                        AZ_REPO="buster"
+                        ;;
+                    Debian11)
+                        AZ_REPO="bullseye"
+                        ;;
+                    Debian12)
+                        AZ_REPO="bookworm"
+                        ;;
+                    *)
+                        echo "Unknown Debian version. Exiting."
+                        exit 1
+                        ;;
+                esac
             fi
+
+            curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+            echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+
+            sudo apt-get update -qq
+            sudo apt-get install azure-cli -y -qq
+        elif [[ $OS == "Fedora" ]]; then
+            echo "Needs Conversation for Fedora"
         fi
-
-        AZ_REPO=$(lsb_release -cs)
-        if [[ $AZ_REPO == "kali-rolling" ]]; then
-            check_version=$(cat /proc/version | awk '{ print $6 $7 }' | tr -d '()' | cut -d . -f 1)
-            case $check_version in
-                Debian10)
-                    AZ_REPO="buster"
-                    ;;
-                Debian11)
-                    AZ_REPO="bullseye"
-                    ;;
-                Debian12)
-                    AZ_REPO="bookworm"
-                    ;;
-                *)
-                    echo "Unknown Debian version. Exiting."
-                    exit 1
-                    ;;
-            esac
-        fi
-
-        curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-
-        sudo apt-get update -qq
-        sudo apt-get install azure-cli -y -qq
-
-    elif [[ $OS == "Fedora" ]]; then
-        echo "Needs Conversation for Fedora"
     fi
 
     echo "Azure CLI updated to version $AzureCliVersion."

--- a/interact/account-helpers/do.sh
+++ b/interact/account-helpers/do.sh
@@ -45,15 +45,7 @@ if [[ "$(printf '%s\n' "$installed_version" "$DoctlVersion" | sort -V | head -n 
         packer plugins install github.com/digitalocean/digitalocean
 
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i | awk '{ print $3 }')
-         if ! command -v lsb_release &> /dev/null; then
-             OS="unknown-Linux"
-             BASEOS="Linux"
-         fi
-    fi
+        OS=$(detect_os)
     if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
             sudo pacman -Syu doctl --noconfirm
         elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then

--- a/interact/account-helpers/exoscale.sh
+++ b/interact/account-helpers/exoscale.sh
@@ -88,15 +88,7 @@ if [[ "$(printf '%s\n' "$installed_version" "$ExoscaleCliVersion" | sort -V | he
 		brew install exoscale-cli
 	
 	elif [[ $BASEOS == "Linux" ]]; then
-		if uname -a | grep -qi "Microsoft"; then
-			OS="UbuntuWSL"
-		else
-			OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-			if ! command -v lsb_release &> /dev/null; then
-				OS="unknown-Linux"
-				BASEOS="Linux"
-			fi
-		fi
+		OS=$(detect_os)
 
         if [[ $OS == "Fedora" ]] || [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
 			echo -e "${BGreen}Installing/Updating exo CLI on $OS...${Color_Off}"

--- a/interact/account-helpers/gcp.sh
+++ b/interact/account-helpers/gcp.sh
@@ -87,21 +87,30 @@ if [[ "$(printf '%s\n' "$installed_version" "$GCloudCliVersion" | sort -V | head
     echo -e "${Yellow}gcloud CLI is either not installed or version is lower than the recommended version in ~/.axiom/interact/includes/vars.sh${Color_Off}"
     echo "Installing/updating gcloud CLI to version $GCloudCliVersion..."
 
-    sudo apt update && sudo apt-get install apt-transport-https ca-certificates gnupg curl -qq -y
-    # Add the Google Cloud GPG key and fix missing GPG key issue
-    echo "Adding the Google Cloud public key..."
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+    OS=$(detect_os)
+    if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
+        echo -e "${BGreen}Installing gcloud CLI via standalone archive on Arch...${Color_Off}"
+        curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+        tar -xf google-cloud-cli-linux-x86_64.tar.gz -C "$HOME"
+        "$HOME"/google-cloud-sdk/install.sh --quiet
+        rm google-cloud-cli-linux-x86_64.tar.gz
+    else
+        sudo apt update && sudo apt-get install apt-transport-https ca-certificates gnupg curl -qq -y
+        # Add the Google Cloud GPG key and fix missing GPG key issue
+        echo "Adding the Google Cloud public key..."
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
-    # Add the correct repository entry for Google Cloud SDK
-    echo "Adding Google Cloud SDK to sources list..."
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        # Add the correct repository entry for Google Cloud SDK
+        echo "Adding Google Cloud SDK to sources list..."
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
-    # Clean up duplicate entries
-    clean_gcloud_repos
+        # Clean up duplicate entries
+        clean_gcloud_repos
 
-    # Update package list and install Google Cloud SDK
-    sudo apt-get update -qq
-    sudo apt-get install google-cloud-sdk -y -qq
+        # Update package list and install Google Cloud SDK
+        sudo apt-get update -qq
+        sudo apt-get install google-cloud-sdk -y -qq
+    fi
     echo "Installing Packer Plugin..."
     packer plugins install github.com/hashicorp/googlecompute
 fi

--- a/interact/account-helpers/hetzner.sh
+++ b/interact/account-helpers/hetzner.sh
@@ -54,15 +54,7 @@ if [[ "$(printf '%s\n' "$installed_version" "$HetznerCliVersion" | sort -V | hea
 
     # Handle Linux installation/update
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
-            fi
-        fi
+        OS=$(detect_os)
 
         # Install or update hcloud on different Linux distributions
         if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then

--- a/interact/account-helpers/ibm-classic.sh
+++ b/interact/account-helpers/ibm-classic.sh
@@ -52,25 +52,11 @@ if [[ "$(printf '%s\n' "$installed_version" "$IBMCloudCliVersion" | sort -V | he
         echo -e "${BGreen}Installing ibmcloud-cli...${Color_Off}"
         curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
-            fi
-        fi
-        if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
-            echo "Needs Conversation for Arch or ManjaroLinux"
-        elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
-            echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
-            curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
-            echo -e "${BGreen}Installing ibmcloud sl (SoftLayer) plugin...${Color_Off}"
-            ibmcloud plugin install sl -q -f
-        elif [[ $OS == "Fedora" ]]; then
-            echo "Needs Conversation for Fedora"
-        fi
+        OS=$(detect_os)
+        echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
+        curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+        echo -e "${BGreen}Installing ibmcloud sl (SoftLayer) plugin...${Color_Off}"
+        ibmcloud plugin install sl -q -f
     fi
 
     echo "ibmcloud-cli updated to version $IBMCloudCliVersion."

--- a/interact/account-helpers/ibm-vpc.sh
+++ b/interact/account-helpers/ibm-vpc.sh
@@ -51,23 +51,9 @@ if [[ "$(printf '%s\n' "$installed_version" "$IBMCloudCliVersion" | sort -V | he
         echo -e "${BGreen}Installing ibmcloud-cli...${Color_Off}"
         curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
-            fi
-        fi
-        if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
-            echo "Needs Conversation for Arch or ManjaroLinux"
-        elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
-            echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
-            curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
-        elif [[ $OS == "Fedora" ]]; then
-            echo "Needs Conversation for Fedora"
-        fi
+        OS=$(detect_os)
+        echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
+        curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
     fi
 
     echo "ibmcloud-cli updated to version $IBMCloudCliVersion."

--- a/interact/account-helpers/linode.sh
+++ b/interact/account-helpers/linode.sh
@@ -69,11 +69,7 @@ if [[ "$acc" == "n" ]]; then
     if [ $BASEOS == "Mac" ]; then
     open "https://www.linode.com/lp/refer/?r=71f79f7e02534d6f673cbc8a17581064e12ac27d"
     elif [ $BASEOS == "Linux" ]; then
-           OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-   if ! command -v lsb_release &> /dev/null; then
-            OS="unknown-Linux"
-            BASEOS="Linux"
-   fi
+        OS=$(detect_os)
        if [ $OS == "Arch" ] || [ $OS == "ManjaroLinux" ]; then
           sudo pacman -Syu xdg-utils --noconfirm
        else

--- a/interact/account-helpers/scaleway.sh
+++ b/interact/account-helpers/scaleway.sh
@@ -62,14 +62,7 @@ if [[ "$(printf '%s\n' "$installed_version" "$ScalewayCliVersion" | sort -V | he
         echo -e "${BGreen}Installing Scaleway CLI (scw)...${Color_Off}"
         brew install scw
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-            fi
-        fi
+        OS=$(detect_os)
 
         # Install or update Scaleway CLI for Linux
         if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then

--- a/interact/axiom-account
+++ b/interact/axiom-account
@@ -62,11 +62,16 @@ if [[ "$(printf '%s\n' "$installed_packer_version" "$PackerVersion" | sort -V | 
     brew install hashicorp/tap/packer
     brew upgrade hashicorp/tap/packer
   else
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-    sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" -y
-    sudo apt-get update && sudo apt-get install packer -y
+    OS=$(detect_os)
+    if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
+      sudo pacman -Syu packer --noconfirm --overwrite '/usr/bin/packer'
+    else
+      curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+      sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" -y
+      sudo apt-get update && sudo apt-get install packer -y
+    fi
 
-    # Check if the apt install failed or the version is still incorrect
+    # Check if the install failed or the version is still incorrect
     installed_packer_version=$(packer version 2>/dev/null | cut -d ' ' -f 2 | cut -d v -f2-)
     if [[ "$(printf '%s\n' "$installed_packer_version" "$PackerVersion" | sort -V | head -n 1)" != "$PackerVersion" ]]; then
       echo -e "${Yellow}Failed to install Packer via package manager or verion version is still lower than the recommended version in ~/.axiom/interact/includes/vars.sh${Color_Off}"
@@ -94,15 +99,7 @@ fi
             wget https://github.com/digitalocean/doctl/releases/download/v${DoctlVersion}/doctl-${DoctlVersion}-darwin-amd64.tar.gz -qO- | tar -xzv -C /usr/local/bin/
             echo "doctl updated to version $DoctlVersion."
     elif [[ $BASEOS == "Linux" ]]; then
-        if uname -a | grep -qi "Microsoft"; then
-            OS="UbuntuWSL"
-        else
-            OS=$(lsb_release -i | awk '{ print $3 }')
-            if ! command -v lsb_release &> /dev/null; then
-                OS="unknown-Linux"
-                BASEOS="Linux"
-            fi
-        fi
+        OS=$(detect_os)
         if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
             sudo pacman -Syu doctl --noconfirm
         elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
@@ -200,31 +197,17 @@ if [[ "$provider" == "ibm-classic" ]] || [[ "$provider" == "ibm-vpc" ]] || [[ "$
              ibmcloud plugin install vpc-infrastructure -q -f
            fi
         elif [[ $BASEOS == "Linux" ]]; then
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
-                fi
+            OS=$(detect_os)
+            if ! [ -x "$(command -v ibmcloud)" ]; then
+                echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
+                curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
             fi
-            if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
-                echo "Needs Conversation for Arch or ManjaroLinux"
-            elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
-                if ! [ -x "$(command -v ibmcloud)" ]; then
-                    echo -e "${BGreen}Installing ibmcloud-cli on Linux...${Color_Off}"
-                    curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
-                fi
             if [[ $provider == "ibm-classic" ]]; then
              echo -e "${BGreen}Installing ibmcloud sl (SoftLayer) plugin...${Color_Off}"
              ibmcloud plugin install sl -q -f
             else
              echo -e "${BGreen}Installing ibmcloud vpc plugin...${Color_Off}"
              ibmcloud plugin install vpc-infrastructure -q -f
-            fi
-            elif [[ $OS == "Fedora" ]]; then
-                echo "Needs Conversation for Fedora"
             fi
         fi
 
@@ -270,47 +253,43 @@ if [[ "$provider" == "azure" ]]; then
 
         # Handle Linux installation/update
         elif [[ $BASEOS == "Linux" ]]; then
-            sudo apt-get update -qq
-            sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y -qq
+            OS=$(detect_os)
 
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
+            if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
+                echo -e "${BGreen}Installing Azure CLI via pip on Arch...${Color_Off}"
+                pip install azure-cli
+            elif [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
+                sudo apt-get update -qq
+                sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y -qq
+
+                AZ_REPO=$(lsb_release -cs)
+                if [[ $AZ_REPO == "kali-rolling" ]]; then
+                    check_version=$(cat /proc/version | awk '{ print $6 $7 }' | tr -d '()' | cut -d . -f 1)
+                    case $check_version in
+                        Debian10)
+                            AZ_REPO="buster"
+                            ;;
+                        Debian11)
+                            AZ_REPO="bullseye"
+                            ;;
+                        Debian12)
+                            AZ_REPO="bookworm"
+                            ;;
+                        *)
+                            echo "Unknown Debian version. Exiting."
+                            exit 1
+                            ;;
+                    esac
                 fi
+                curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+                echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+
+                sudo apt-get update -qq
+                sudo apt-get purge azure-cli -y -qq
+                sudo apt-get install azure-cli -y -qq
+            elif [[ $OS == "Fedora" ]]; then
+                echo "Needs Conversation for Fedora"
             fi
-
-            AZ_REPO=$(lsb_release -cs)
-            if [[ $AZ_REPO == "kali-rolling" ]]; then
-                check_version=$(cat /proc/version | awk '{ print $6 $7 }' | tr -d '()' | cut -d . -f 1)
-                case $check_version in
-                    Debian10)
-                        AZ_REPO="buster"
-                        ;;
-                    Debian11)
-                        AZ_REPO="bullseye"
-                        ;;
-                    Debian12)
-                        AZ_REPO="bookworm"
-                        ;;
-                    *)
-                        echo "Unknown Debian version. Exiting."
-                        exit 1
-                        ;;
-                esac
-            fi
-            curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-            echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-
-            sudo apt-get update -qq
-            sudo apt-get purge azure-cli -y -qq
-            sudo apt-get install azure-cli -y -qq
-
-        elif [[ $OS == "Fedora" ]]; then
-            echo "Needs Conversation for Fedora"
         fi
   fi 
  # Authenticate using client credentials stored in axiom.json
@@ -356,18 +335,10 @@ if [[ "$provider" == "aws" ]]; then
             rm AWSCLIV2.pkg
 
         elif [[ $BASEOS == "Linux" ]]; then
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
-                fi
-            fi
+            OS=$(detect_os)
 
             # Install AWS CLI based on specific Linux distribution
-            if [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
+            if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]] || [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
                 echo -e "${BGreen}Installing/Updating AWS CLI on $OS...${Color_Off}"
                 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
                 cd /tmp
@@ -437,21 +408,20 @@ if [[ "$provider" == "gcp" ]]; then
             curl https://sdk.cloud.google.com | bash
             exec -l $SHELL
         elif [[ $BASEOS == "Linux" ]]; then
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
-                fi
-            fi
+            OS=$(detect_os)
 
             echo -e "${BGreen}Installing/Updating gcloud CLI on Linux...${Color_Off}"
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            sudo apt-get install apt-transport-https ca-certificates gnupg -y -qq
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.gpg > /dev/null
-            sudo apt-get update -qq && sudo apt-get install google-cloud-sdk -y -qq
+            if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
+                curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+                tar -xf google-cloud-cli-linux-x86_64.tar.gz -C "$HOME"
+                "$HOME"/google-cloud-sdk/install.sh --quiet
+                rm google-cloud-cli-linux-x86_64.tar.gz
+            else
+                echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+                sudo apt-get install apt-transport-https ca-certificates gnupg -y -qq
+                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.gpg > /dev/null
+                sudo apt-get update -qq && sudo apt-get install google-cloud-sdk -y -qq
+            fi
         fi
     fi
 
@@ -501,15 +471,7 @@ if [[ "$provider" == "hetzner" ]]; then
 
         # Handle Linux installation/update
         elif [[ $BASEOS == "Linux" ]]; then
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
-                fi
-            fi
+            OS=$(detect_os)
 
             # Install or update hcloud on different Linux distributions
             if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
@@ -568,15 +530,7 @@ if [[ "$provider" == "scaleway" ]]; then
 
         # Handle Linux installation/update
         elif [[ $BASEOS == "Linux" ]]; then
-            if uname -a | grep -qi "Microsoft"; then
-                OS="UbuntuWSL"
-            else
-                OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-                if ! command -v lsb_release &> /dev/null; then
-                    OS="unknown-Linux"
-                    BASEOS="Linux"
-                fi
-            fi
+            OS=$(detect_os)
 
             # Install or update scaleway-cli on different Linux distributions
             if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
@@ -635,15 +589,7 @@ if [[ "$provider" == "exoscale" ]]; then
     		brew install exoscale-cli
 
     	elif [[ $BASEOS == "Linux" ]]; then
-    		if uname -a | grep -qi "Microsoft"; then
-    			OS="UbuntuWSL"
-    		else
-    			OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-    			if ! command -v lsb_release &> /dev/null; then
-    				OS="unknown-Linux"
-    				BASEOS="Linux"
-    			fi
-    		fi
+    		OS=$(detect_os)
 
             if [[ $OS == "Fedora" ]] || [[ $OS == "Ubuntu" ]] || [[ $OS == "Debian" ]] || [[ $OS == "Linuxmint" ]] || [[ $OS == "Parrot" ]] || [[ $OS == "Kali" ]] || [[ $OS == "unknown-Linux" ]] || [[ $OS == "UbuntuWSL" ]]; then
     			echo -e "${BGreen}Installing/Updating exo CLI on $OS...${Color_Off}"

--- a/interact/axiom-configure
+++ b/interact/axiom-configure
@@ -129,7 +129,13 @@ function bash_shell(){
 
 function zsh_shell(){
     timestamp=$(date +%Y-%m-%d_%H-%M-%S)
-    sudo apt install zsh -y
+    if [[ "$OS" == "Arch" ]] || [[ "$OS" == "ManjaroLinux" ]]; then
+        sudo pacman -S zsh --noconfirm
+    elif [[ "$OS" == "Fedora" ]]; then
+        sudo dnf install zsh -y
+    else
+        sudo apt install zsh -y
+    fi
     echo -e "${BGreen}Backing up $(echo "$HOME"/.zshrc) to $(echo "$HOME"/.zshrc-$timestamp) just in case.${Color_Off}"
     cp "$HOME"/.zshrc "$HOME"/.zshrc-$timestamp >> /dev/null 2>&1
 
@@ -187,7 +193,13 @@ function omz_shell(){
     echo -e "${BGreen}Backing up $(echo "$HOME"/.oh-my-zsh/) to $(echo "$HOME"/.oh-my-zsh-$timestamp) just in case.${Color_Off}"
     mv "$HOME"/.oh-my-zsh "$HOME"/.oh-my-zsh-$timestamp >> /dev/null 2>&1
 
-    sudo apt install zsh zsh-syntax-highlighting zsh-autosuggestions -y
+    if [[ "$OS" == "Arch" ]] || [[ "$OS" == "ManjaroLinux" ]]; then
+        sudo pacman -S zsh zsh-syntax-highlighting zsh-autosuggestions --noconfirm
+    elif [[ "$OS" == "Fedora" ]]; then
+        sudo dnf install zsh zsh-syntax-highlighting zsh-autosuggestions -y
+    else
+        sudo apt install zsh zsh-syntax-highlighting zsh-autosuggestions -y
+    fi
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
     if [[ "$unattended" == "true" ]]; then
         echo -e "${BGreen}Installing Golang ${GolangVersion}${Color_Off}"
@@ -378,12 +390,41 @@ if [[ $BASEOS == "Linux" ]]; then
         OS="UbuntuWSL"
     else
         OS=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
-        if ! command -v lsb_release &> /dev/null; then
-            echo -e "${Yellow}WARNING: lsb_release not found. Unless using Ubuntu latest, this install might not work${Color_Off}"
-            echo "lsb_release could not be found, unable to determine your distribution"
-            OS="unknown-Linux"
-            BASEOS="Linux"
-        fi
+        # Check if lsb_release returned a known distro
+        case "$OS" in
+            Arch|ManjaroLinux|Ubuntu|Debian|Kali|Linuxmint|Parrot|Fedora) ;;
+            *)
+                # lsb_release unavailable or returned unknown distro, try /etc/os-release
+                if [[ -f /etc/os-release ]]; then
+                    OS=$(. /etc/os-release && echo "$ID")
+                    case "$OS" in
+                        arch)       OS="Arch" ;;
+                        manjaro)    OS="ManjaroLinux" ;;
+                        ubuntu)     OS="Ubuntu" ;;
+                        debian)     OS="Debian" ;;
+                        kali)       OS="Kali" ;;
+                        linuxmint)  OS="Linuxmint" ;;
+                        parrot)     OS="Parrot" ;;
+                        fedora)     OS="Fedora" ;;
+                        *)
+                            # Fallback to ID_LIKE for derivatives (CachyOS, EndeavourOS, Garuda, etc.)
+                            _id_like=$(. /etc/os-release && echo "$ID_LIKE")
+                            case "$_id_like" in
+                                arch|arch*) OS="Arch" ;;
+                                debian*)    OS="Debian" ;;
+                                ubuntu*)    OS="Ubuntu" ;;
+                                fedora*)    OS="Fedora" ;;
+                                *)          OS="unknown-Linux" ; BASEOS="Linux" ;;
+                            esac
+                            ;;
+                    esac
+                else
+                    echo -e "${Yellow}WARNING: Unable to determine your distribution${Color_Off}"
+                    OS="unknown-Linux"
+                    BASEOS="Linux"
+                fi
+                ;;
+        esac
     fi
     if [[ $OS == "Arch" ]] || [[ $OS == "ManjaroLinux" ]]; then
         echo -e "${BGreen}Congrats, you run arch..."

--- a/interact/includes/vars.sh
+++ b/interact/includes/vars.sh
@@ -45,6 +45,52 @@ export ExoscaleCliVersion="1.84.0"
 # Auto Update Option
 [ -f $AXIOM_PATH/interact/includes/.auto_update ] && source $AXIOM_PATH/interact/includes/.auto_update
 
+# Detect Linux distribution, works with or without lsb_release
+# Uses /etc/os-release as fallback, with ID_LIKE for derivatives (CachyOS, EndeavourOS, Garuda, etc.)
+detect_os() {
+    if uname -a | grep -qi "Microsoft"; then
+        echo "UbuntuWSL"
+        return
+    fi
+    local os
+    os=$(lsb_release -i 2>/dev/null | awk '{ print $3 }')
+    # Normalize known distro names from lsb_release
+    case "$os" in
+        Arch)          echo "Arch" ; return ;;
+        ManjaroLinux)  echo "ManjaroLinux" ; return ;;
+        Ubuntu)        echo "Ubuntu" ; return ;;
+        Debian)        echo "Debian" ; return ;;
+        Kali)          echo "Kali" ; return ;;
+        Linuxmint)     echo "Linuxmint" ; return ;;
+        Parrot)        echo "Parrot" ; return ;;
+        Fedora)        echo "Fedora" ; return ;;
+    esac
+    # lsb_release returned unknown or empty value, try /etc/os-release
+    if [[ -f /etc/os-release ]]; then
+        os=$(. /etc/os-release && echo "$ID")
+        case "$os" in
+            arch)       echo "Arch" ; return ;;
+            manjaro)    echo "ManjaroLinux" ; return ;;
+            ubuntu)     echo "Ubuntu" ; return ;;
+            debian)     echo "Debian" ; return ;;
+            kali)       echo "Kali" ; return ;;
+            linuxmint)  echo "Linuxmint" ; return ;;
+            parrot)     echo "Parrot" ; return ;;
+            fedora)     echo "Fedora" ; return ;;
+        esac
+        # Check ID_LIKE for derivatives (e.g. CachyOS, EndeavourOS, Garuda have ID_LIKE=arch)
+        local id_like
+        id_like=$(. /etc/os-release && echo "$ID_LIKE")
+        case "$id_like" in
+            arch|arch*) echo "Arch" ; return ;;
+            debian*)    echo "Debian" ; return ;;
+            ubuntu*)    echo "Ubuntu" ; return ;;
+            fedora*)    echo "Fedora" ; return ;;
+        esac
+    fi
+    echo "unknown-Linux"
+}
+
 # Shared function across all proviers, since these functions only query an ssh configuration file
 # check if instance name is in .sshconfig
 # used by axiom-scan


### PR DESCRIPTION
## Summary
- Add `detect_os()` function to `vars.sh` that uses `/etc/os-release` with `ID_LIKE` fallback, supporting Arch derivatives (CachyOS, EndeavourOS, Garuda, ArcoLinux, etc.)
- Fix OS detection across `axiom-configure`, `axiom-account`, and all 10 account helpers — replacing fragile `lsb_release` checks with the new `detect_os()` function
- Fix `zsh_shell()` and `omz_shell()` in `axiom-configure` to use `pacman` on Arch instead of hardcoded `apt`
- Add Arch branches for cloud provider CLIs: AWS (zip install), Azure (`pip install`), GCP (standalone archive)
- Fix Packer install in `axiom-account` to use `pacman` on Arch
- Update README: Arch Linux Easy Install `No` → `Yes`

## Test plan
- [x] Tested on CachyOS (`ID=cachyos`, `ID_LIKE=arch`) — `detect_os` correctly returns `Arch`
- [x] `axiom-configure --run` detects Arch, installs deps via pacman, completes shell setup
- [x] `axiom-account` Packer install uses pacman on Arch (with `--overwrite` for existing binaries)
- [x] Full easy install flow completes successfully on CachyOS (DigitalOcean provider)
- [ ] Regression test on Ubuntu/Debian (no behavior change expected — `lsb_release` is still used as primary detection)